### PR TITLE
Issue/74 show staff when hired

### DIFF
--- a/Assets/Code/Factories/ComputerFactory.cs
+++ b/Assets/Code/Factories/ComputerFactory.cs
@@ -77,9 +77,7 @@ namespace Code.Factories {
       newComputer.gameObject.name = $"Computer--{newComputer.Data.component_name}";
 
       //add it to the computer list.
-      var componentList = this.computerListVariable.Value;
-      componentList.Add(newComputer);
-      computerListVariable.Value = new List<ComputerBehavior>(componentList);
+      computerListVariable.Add(newComputer);
     }
 
     //-------------------------------------------------------------------------

--- a/Assets/Code/IPCManagerScript.cs
+++ b/Assets/Code/IPCManagerScript.cs
@@ -71,12 +71,7 @@ public class IPCManagerScript : MonoBehaviour {
           gameStatusChanged?.Raise(message);
           break;
         case "attack_log":
-          //Debug.Log("got status %s" + message);
-          // AttackLogScript.AddEntry(message);
-          var logs = attackLogVariable.Value;
-          logs.Add(message);
-          //note: have to create a new List in order to trigger the OnChanged() event
-          attackLogVariable.Value = new List<string>(logs);
+          attackLogVariable.Add(message);
           break;
         case "load_computer":
           _computerFactory.Create(message + ".sdf");

--- a/Assets/Code/Scriptable Variables/ListVariable.cs
+++ b/Assets/Code/Scriptable Variables/ListVariable.cs
@@ -7,9 +7,8 @@ namespace Code.Scriptable_Variables {
 
     //Add an item to the list. Note, this creates a whole new List with the item added to it.
     public void Add(T item) {
-      var thisList = Value;
-      thisList.Add(item);
-      Value = new List<T>(thisList);
+      Value.Add(item);
+      ValueChanged();
     }
   }
 }

--- a/Assets/Code/Scriptable Variables/ListVariable.cs
+++ b/Assets/Code/Scriptable Variables/ListVariable.cs
@@ -4,6 +4,12 @@ using Shared.ScriptableVariables;
 namespace Code.Scriptable_Variables {
   //Base placeholder for ScriptableVariables that contain a list
   public class ListVariable<T> : ScriptableVariable<List<T>> {
-    
+
+    //Add an item to the list. Note, this creates a whole new List with the item added to it.
+    public void Add(T item) {
+      var thisList = Value;
+      thisList.Add(item);
+      Value = new List<T>(thisList);
+    }
   }
 }

--- a/Assets/Code/Scriptable Variables/StaffListVariable.cs
+++ b/Assets/Code/Scriptable Variables/StaffListVariable.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+namespace Code.Scriptable_Variables {
+  [CreateAssetMenu(menuName = "Scriptable Objects/Variables/CC/Staff List")]
+  public class StaffListVariable : ListVariable<StaffBehavior> {
+    //---------------------------------------------------------------------------
+    [ContextMenu("Reset To Default Value")]
+    public void ContextMenuReset() {
+      Reset();
+    }
+  }
+  
+    
+#if UNITY_EDITOR
+//-----------------------------------------------------------------------------
+  [UnityEditor.CustomEditor(typeof(StaffListVariable))]
+  [UnityEditor.CanEditMultipleObjects]
+  public class StaffListVariableVariableEditor : StaffListVariable.BaseScriptableVariableEditor {
+  }
+#endif
+}

--- a/Assets/Code/Scriptable Variables/StaffListVariable.cs.meta
+++ b/Assets/Code/Scriptable Variables/StaffListVariable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 927a57c92b0f4239bb949e793bc34986
+timeCreated: 1611344667

--- a/Assets/Code/StaffBehavior.cs
+++ b/Assets/Code/StaffBehavior.cs
@@ -1,37 +1,14 @@
-﻿using System.Xml.Linq;
-using Code.Factories;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace Code {
+  //Represents a single Staff member
   public class StaffBehavior : MonoBehaviour {
     [SerializeField] private StaffDataObject _data;
-  
-    private static Rect WindowRect = new Rect(10, 10, 250, 300);
 
     public StaffDataObject Data {
       get => _data;
       set => _data = value;
     }
 
-    public static void doItems() {
-      WindowRect = GUI.Window(1, WindowRect, HireMenu, "Hire IT/Security");
-    }
-
-    private static void HireMenu(int id) {
-      foreach (string key in StaffFactory.staff_dict.Keys)
-        if (GUILayout.Button(key)) {
-          StaffBehavior script = StaffFactory.staff_dict[key];
-          // TBD fix cost / salary to match game
-          XElement xml = new XElement("userEvent",
-            new XElement("hire",
-              new XElement("name", script.Data.user_name),
-              new XElement("salary", script.Data.cost)),
-            new XElement("cost", script.Data.cost));
-
-          Debug.Log(xml);
-          IPCManagerScript.SendRequest(xml.ToString());
-          menus.clicked = "";
-        }
-    }
   }
 }

--- a/Assets/Code/StaffDataObject.cs
+++ b/Assets/Code/StaffDataObject.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine;
 
 namespace Code {
   //Data relating to one StaffBehavior instance
@@ -14,6 +15,19 @@ namespace Code {
     public int sw_skill;
     public int cost;
     public int salary;
+    
+    [Tooltip("The number of days until this staff is available to hire." +
+             "-1 = already hired, 0 = available now, 2 = wait for two days.")]
+    public int daysTillAvailable = -1;
 
+    //--------------------------------------------------------------------------
+    public bool IsCurrentlyHired() {
+      return daysTillAvailable < 0;
+    }
+
+    //--------------------------------------------------------------------------
+    public bool CanBeHiredNow() {
+      return daysTillAvailable == 0;
+    }
   }
 }

--- a/Assets/Code/StaffDataObject.cs
+++ b/Assets/Code/StaffDataObject.cs
@@ -29,5 +29,10 @@ namespace Code {
     public bool CanBeHiredNow() {
       return daysTillAvailable == 0;
     }
+
+    //--------------------------------------------------------------------------
+    public void SetHired(bool hired) {
+      daysTillAvailable = hired ? -1 : 0;
+    }
   }
 }

--- a/Assets/Code/menus.cs
+++ b/Assets/Code/menus.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using Code;
+using Code.Factories;
 using Code.Scriptable_Variables;
 using NaughtyAttributes;
 using UltimateCameraController.Cameras.Controllers;
@@ -13,6 +14,9 @@ public class menus : MonoBehaviour {
   [Tooltip("The scriptable variable that contains a list of the current" +
            " Zones in the scenario.")]
   [SerializeField] private ZoneListVariable _zoneListVariable;
+
+  [Tooltip("The factory/manager that deals with all Staff")]
+  [SerializeField] private StaffFactory _staffFactory;
 
   [Tooltip("The Camera controller to use when jumping between items in the scenario")]
   [SerializeField] private CameraController _cameraController;
@@ -200,7 +204,7 @@ public class menus : MonoBehaviour {
       clicked = "";
     }
     else if (clicked == "Hire") {
-      StaffBehavior.doItems();
+      _staffFactory.doItems();
     }
     else if (clicked == "Zones") {
       ZoneBehavior.doItems(_zoneListVariable.Value);

--- a/Assets/Prefabs/People/Staff IT.prefab
+++ b/Assets/Prefabs/People/Staff IT.prefab
@@ -893,7 +893,7 @@ GameObject:
   - component: {fileID: 1087776242062782614}
   - component: {fileID: 1087776242062782609}
   m_Layer: 0
-  m_Name: ITStaff
+  m_Name: Staff IT
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -946,16 +946,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 09702b547ae1b554b8799011e93dac9c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  user_name: 
-  position: -1
-  department: 
-  current_thought: 
-  skill: 0
-  hw_skill: 0
-  hi_skill: 0
-  sw_skill: 0
-  cost: 0
-  salary: 0
+  _data:
+    user_name: 
+    position: -1
+    department: 
+    current_thought: 
+    skill: 0
+    hw_skill: 0
+    hi_skill: 0
+    sw_skill: 0
+    cost: 0
+    salary: 0
+    daysTillAvailable: -1
 --- !u!1 &1087776242092569196
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/People/Staff Security Guard.prefab
+++ b/Assets/Prefabs/People/Staff Security Guard.prefab
@@ -75,6 +75,7 @@ MonoBehaviour:
     sw_skill: 0
     cost: 0
     salary: 0
+    daysTillAvailable: -1
 --- !u!1001 &9080269969214913232
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/cyber1.unity
+++ b/Assets/Scenes/cyber1.unity
@@ -316,6 +316,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5dd01a6f70794adba2316e03b5df3947, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _staffListVariable: {fileID: 11400000, guid: bb81c43d222433549a0af763cf35c0be, type: 2}
   _prefabMapping: {fileID: 11400000, guid: 00d8e0ec77f2295499dac3b15a7de8f5, type: 2}
 --- !u!1 &155726752
 GameObject:
@@ -1005,6 +1006,8 @@ MonoBehaviour:
   resettables:
   - {fileID: 11400000, guid: c112593a94ef1824eb659aa87624cd5a, type: 2}
   - {fileID: 11400000, guid: 7b9705be4efa88f4f83f6bcaf84ee5bd, type: 2}
+  - {fileID: 11400000, guid: 8380099111649e944adcc17e9f804d36, type: 2}
+  - {fileID: 11400000, guid: bb81c43d222433549a0af763cf35c0be, type: 2}
   resetComplete: {fileID: 0}
 --- !u!4 &523011746
 Transform:
@@ -2956,6 +2959,11 @@ PrefabInstance:
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2105339841513253487, guid: dd0399aed0d5ede48aa1e2581709654e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3176805058651691880, guid: dd0399aed0d5ede48aa1e2581709654e,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -3179,6 +3187,16 @@ PrefabInstance:
     - target: {fileID: 3985532482584604601, guid: dd0399aed0d5ede48aa1e2581709654e,
         type: 3}
       propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143874339388157129, guid: dd0399aed0d5ede48aa1e2581709654e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4143874339388157129, guid: dd0399aed0d5ede48aa1e2581709654e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5429223504127285694, guid: dd0399aed0d5ede48aa1e2581709654e,

--- a/Assets/Scenes/cyber1.unity
+++ b/Assets/Scenes/cyber1.unity
@@ -317,6 +317,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _staffListVariable: {fileID: 11400000, guid: bb81c43d222433549a0af763cf35c0be, type: 2}
+  _hireStaffEvent: {fileID: 11400000, guid: 854db83451cff0f45a020554cd67f84b, type: 2}
   _prefabMapping: {fileID: 11400000, guid: 00d8e0ec77f2295499dac3b15a7de8f5, type: 2}
 --- !u!1 &155726752
 GameObject:
@@ -361,7 +362,7 @@ Transform:
   m_Children:
   - {fileID: 1357966140}
   m_Father: {fileID: 0}
-  m_RootOrder: 20
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &206987052
 GameObject:
@@ -391,7 +392,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &272680802
 GameObject:
@@ -1446,6 +1447,37 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _prefab: {fileID: 1782108855848456436, guid: c45b44ff3b325db44b854d5ae1fbc984, type: 3}
+--- !u!1 &1035028165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1035028166}
+  m_Layer: 0
+  m_Name: Staff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &1035028166
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1035028165}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1588824131}
+  m_Father: {fileID: 0}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1042012300
 GameObject:
   m_ObjectHideFlags: 0
@@ -2437,7 +2469,7 @@ Transform:
   - {fileID: 491480235}
   - {fileID: 1705435007}
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1477638164 stripped
 RectTransform:
@@ -2555,6 +2587,65 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _prefab: {fileID: 7122772725586760942, guid: 45d011668db1a8d4d95adf3eea0a0d57, type: 3}
+--- !u!1 &1588824130
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1588824131}
+  - component: {fileID: 1588824132}
+  m_Layer: 0
+  m_Name: Hire Staff Listener
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1588824131
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1588824130}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1035028166}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1588824132
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1588824130}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ace966faabda0734887c2cb816d27c30, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  delay: 0
+  eventToListenTo: {fileID: 11400000, guid: 854db83451cff0f45a020554cd67f84b, type: 2}
+  response:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 116868716}
+        m_MethodName: HireStaff
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &1638482055
 GameObject:
   m_ObjectHideFlags: 0
@@ -3894,6 +3985,21 @@ PrefabInstance:
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6679614322571519308, guid: dd0399aed0d5ede48aa1e2581709654e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6679614322571519308, guid: dd0399aed0d5ede48aa1e2581709654e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6679614322571519308, guid: dd0399aed0d5ede48aa1e2581709654e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8559687118465474714, guid: dd0399aed0d5ede48aa1e2581709654e,
         type: 3}
       propertyPath: m_AnchorMax.x
@@ -4331,6 +4437,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _zoneListVariable: {fileID: 11400000, guid: 7b9705be4efa88f4f83f6bcaf84ee5bd, type: 2}
+  _staffFactory: {fileID: 116868716}
   _cameraController: {fileID: 1230447747}
   guiSkin: {fileID: 0}
   _computerPanel: {fileID: 1199081107441465558}
@@ -5334,6 +5441,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2381771226113103281, guid: 3bb52e695fa0de741a2a96f3d3c1c715,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 2381771226287637031, guid: 3bb52e695fa0de741a2a96f3d3c1c715,
         type: 3}

--- a/Assets/ScriptableObjects/Event - Hire Staff.asset
+++ b/Assets/ScriptableObjects/Event - Hire Staff.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d499e67a7f1c28e41b5dc652ff881d53, type: 3}
+  m_Name: Event - Hire Staff
+  m_EditorClassIdentifier: 
+  description: Fired when the Player wants to hire a particular staff. Value is the
+    staff member name.

--- a/Assets/ScriptableObjects/Event - Hire Staff.asset.meta
+++ b/Assets/ScriptableObjects/Event - Hire Staff.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 854db83451cff0f45a020554cd67f84b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Staff List.asset
+++ b/Assets/ScriptableObjects/Staff List.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 927a57c92b0f4239bb949e793bc34986, type: 3}
+  m_Name: Staff List
+  m_EditorClassIdentifier: 
+  description: A list of all the current Staff in the scenario.
+  value:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  defaultValue: []

--- a/Assets/ScriptableObjects/Staff List.asset.meta
+++ b/Assets/ScriptableObjects/Staff List.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bb81c43d222433549a0af763cf35c0be
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Closes #74 

These changes contain the logic of showing which staff can be hired in the temp context menu. If the player hires a staff member, the associated Staff GameObject becomes active and visible in the scene.

To test:
- Run the Physical Security scenario which has three different Staff (one is already hired, two are available to hire).
- Check the scene hierarchy for "Staff--" GameObjects. Should be one activated, two deactivated.
- Right-click->Hire and notice two staff available to hire.
- Click one of them and notice two of the three GameObjects are now active
- Right-Click->Hire and notice only one more staff is available to hire.

Note: the position of the newly hired Staff GameObjects isn't being set (#79)

![image](https://user-images.githubusercontent.com/7308321/105552810-4fa74700-5cb9-11eb-8dd9-fb0affdc9f89.png)
