### PR TITLE
issue/79-position-staff

### DIFF
--- a/Assets/Code/Factories/StaffFactory.cs
+++ b/Assets/Code/Factories/StaffFactory.cs
@@ -170,6 +170,18 @@ namespace Code.Factories {
     
     //--------------------------------------------------------------------------
     private static void UpdateGameObject(StaffBehavior staff) {
+      //Position the new Staff based on their "position", read from the .sdf file.
+      WorkSpace ws = WorkspaceFactory.GetWorkSpace(staff.Data.position);
+      if (ws == null) {
+        Debug.Log($"Can't find a position to place {staff.Data.user_name} with position {staff.Data.position}");
+      }
+      else {
+        ccUtils.GridTo3dPos(ws.x, ws.y, out float xf, out float zf);
+        // Vector3 v = new Vector3(xf - 1.0f, 0.5f, zf); //TODO what were these offsets for?
+        staff.transform.position = new Vector3(xf, 0, zf);
+      }
+      
+      //activate and rename
       staff.gameObject.SetActive(staff.Data.IsCurrentlyHired());
       staff.gameObject.name = $"Staff-{staff.Data.department}--{staff.Data.user_name}";
     }


### PR DESCRIPTION
Closes #79 
This just _roughly_ positions the staff when they are created, using their "position index" defined in the .sdf file.

To verify:
- Run the Physical Security scenario in Unity and in the original game
- Notice the room "Tom" is in. Hint, you can hit the "I" key in the OG. In Unity, its easiest to use the Scene view.
- Hire both "Dead Eye" and "Joey D" in both games and verify their positions roughly match. Note, these two security guards are defined to start at the same location -- they will appear to be merged together.

![image](https://user-images.githubusercontent.com/7308321/105742056-e2312b80-5eef-11eb-9e0c-b36f40e4dd72.png)
![image](https://user-images.githubusercontent.com/7308321/105742123-f6752880-5eef-11eb-86ee-01d59796a57c.png)

