### PR TITLE
Merge Request for Issue/157 - physical security refund

### DIFF
--- a/Assets/Code/Policy/Policy.cs
+++ b/Assets/Code/Policy/Policy.cs
@@ -11,12 +11,27 @@ namespace Code.Policies {
     public string displayName;
     [Tooltip("How much it costs to enforce this policy")]
     public int cost;
+    [Tooltip("Can this policy be refunded when disabled?")]
+    public bool canGetRefund;
     [Tooltip("Can this policy be toggled off by clicking on it?")]
     public bool canToggleOff = true;
 
     // ------------------------------------------------------------------------
     public string GetName() {
       return $"{tag}:{subTag}";
+    }
+
+    // ------------------------------------------------------------------------
+    public int CostToToggle(bool enable) {
+      // If we're enabling it, it's negative the full cost
+      if (enable) {
+        return -cost;
+      }
+      // If we're disabling it and can't get a refund it, it's half its cost to disable it
+      else if (!canGetRefund) {
+        return -cost / 2;
+      }
+      return cost;
     }
   }
 }

--- a/Assets/Code/User Interface/Policies/PolicyListItem.cs
+++ b/Assets/Code/User Interface/Policies/PolicyListItem.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Globalization;
+using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
 using Code.Policies;
@@ -13,13 +14,13 @@ namespace Code.User_Interface.Policies {
     [Tooltip("The button that allows selecting this policy item.")]
     [SerializeField] private Button selectionButton;
 
-    private int _cost = 0;
+    private Policy _policy;
 
     //-------------------------------------------------------------------------
     public override void SetItem(Policy policy) {
       name = policy.displayName;
       nameLabel.text = policy.displayName;
-      _cost = policy.cost;
+      _policy = policy;
       UpdateCostLabel();
     }
 
@@ -36,9 +37,11 @@ namespace Code.User_Interface.Policies {
 
     //-------------------------------------------------------------------------
     private void UpdateCostLabel() {
-      if (_cost > 0) {
+      if (_policy.cost > 0) {
         // Our cost is halved if the policy is enabled
-        costLabel.text = string.Format("{0:C}", IsSelected() ? _cost / 2 : _cost);
+        CultureInfo culture = CultureInfo.CreateSpecificCulture("en-US");
+        culture.NumberFormat.CurrencyNegativePattern = 1;
+        costLabel.text = string.Format(culture, "{0:C}", _policy.CostToToggle(!IsSelected()));
       }
       else {
         costLabel.text = "";

--- a/Assets/Code/User Interface/Policies/PolicyManager.cs
+++ b/Assets/Code/User Interface/Policies/PolicyManager.cs
@@ -76,10 +76,21 @@ namespace Code.Policies {
         new XElement("name", objectName),
         new XElement(settingField,
           new XElement("field", policy.GetName()),
-          new XElement("value", isOn)),
-        new XElement("cost", isOn ? policy.cost : policy.cost / 2));
+          new XElement("value", isOn))
+      );
 
       IPCManagerScript.SendRequest(xml.ToString());
+
+      // TODO: Remove this once server handles policy refunds correctly
+      // If this policy can be refunded and we disabled it, we have to undo
+      // the cost from the server for disabling it AND for enabling it
+      if (policy.canGetRefund && !isOn) {
+        var costXML = new XElement("userEvent",
+          new XElement("cost", -policy.cost * 1.5)
+        );
+
+        IPCManagerScript.SendRequest(costXML.ToString());
+      }
     }
   }
 }

--- a/Assets/ScriptableObjects/Policies/Physical Security/Card Reader.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Card Reader.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Card Reader
   cost: 750
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/DNA Scanner.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/DNA Scanner.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: DNA Scanner
   cost: 350
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Escorted Visitors.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Escorted Visitors.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Escorted Visitors
   cost: 100
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Guard At Door.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Guard At Door.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Guard At Door
   cost: 150
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Hand Scanner.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Hand Scanner.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Hand Scanner
   cost: 750
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Iris Scanner.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Iris Scanner.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Iris Scanner
   cost: 750
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Lock Cypher.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Lock Cypher.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Cypher Lock
   cost: 400
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Lock Key.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Lock Key.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Key Lock
   cost: 25
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Lock Smart.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Lock Smart.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Smart Lock
   cost: 400
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Log All Entry.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Log All Entry.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Log All Entry
   cost: 100
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Patrolling Guard.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Patrolling Guard.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Patrolling Guard
   cost: 150
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Photo ID Badge.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Photo ID Badge.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Photo ID Badge
   cost: 250
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Prohibit Media.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Prohibit Media.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Prohibit Media
   cost: 100
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Prohibit Phones.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Prohibit Phones.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Prohibit Phones
   cost: 100
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Receptionist.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Receptionist.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Receptionist Present
   cost: 100
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Reinforced Walls.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Reinforced Walls.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Reinforced Walls
   cost: 85000
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Scan Visitors.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Scan Visitors.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Scan Visitors
   cost: 100
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Surveillance Cameras.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Surveillance Cameras.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Surveillance Cameras
   cost: 150000
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Visual Inspection.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Visual Inspection.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Visual Inspection
   cost: 100
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/X-Ray Packages.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/X-Ray Packages.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: X-Ray Packages
   cost: 250000
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Zone Alarm Basic.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Zone Alarm Basic.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Basic Zone Alarm
   cost: 1400
+  canGetRefund: 1
   canToggleOff: 1

--- a/Assets/ScriptableObjects/Policies/Physical Security/Zone Alarm Good.asset
+++ b/Assets/ScriptableObjects/Policies/Physical Security/Zone Alarm Good.asset
@@ -16,4 +16,5 @@ MonoBehaviour:
   subTag: 
   displayName: Good Zone Alarm
   cost: 100000
+  canGetRefund: 1
   canToggleOff: 1


### PR DESCRIPTION
Closes #157 

To test:
- Run any scenario and open Zone View
- Select a zone and toggle a physical security on and off
- Make sure funds for the policy are returned when it's disabled

Note:
- You'll see the funds go down even further and then go up when disabling the physical security, this is because the server seems to make you pay for any policy disabling, so I had to send a different event to refund that cost and the original cost of the policy.  Hopefully there will be some server changes to calculate this refund correctly and we can take out my refund hack