### PR TITLE
issue/169-impl-scrap-computer

### DIFF
--- a/Assets/Code/Factories/ComputerFactory.cs
+++ b/Assets/Code/Factories/ComputerFactory.cs
@@ -21,6 +21,8 @@ namespace Code.Factories {
     [SerializeField] private WorkSpaceListVariable _workSpaceListVariable;
     [Tooltip("List of policy lists that computers care about")]
     public List<PolicyListVariable> policies = new List<PolicyListVariable>();
+    [Tooltip("The variable that contains the currently in-game selected World Object")]
+    [SerializeField] private GameObjectVariable _currentlySelectedWorldObject;
 
     [Header("Output Variables")]
     [Tooltip("The variable containing the list of all the Computers currently in the scenario.")]
@@ -59,6 +61,11 @@ namespace Code.Factories {
     //-------------------------------------------------------------------------
     public void Remove(ComputerBehavior computer) {
       computerListVariable.Remove(computer);
+
+      //if this Computer was currently selected, deselect it
+      if (_currentlySelectedWorldObject.Value == computer.gameObject) {
+        _currentlySelectedWorldObject.Value = null;
+      }
 
       //update the WorkSpace
       WorkSpace ws = _workSpaceListVariable.GetWorkSpace(computer.Data.position);

--- a/Assets/Code/World Objects/Computer/ComputerManager.cs
+++ b/Assets/Code/World Objects/Computer/ComputerManager.cs
@@ -1,25 +1,22 @@
 ﻿using System.Xml.Linq;
-using Code.Factories;
 using UnityEngine;
 
 namespace Code.World_Objects.Computer {
   //Handles some functionality for ComputerBehaviors
   public class ComputerManager : MonoBehaviour {
-    [Tooltip("The ComputerFactory to use for adding/deleting computers.")]
-    [SerializeField] private ComputerFactory _computerFactory;
 
     //--------------------------------------------------------------------------
     public void OnScrapComputer(ComputerBehavior computer) {
-      //TODO Notify the game server this computer should be removed
+      //Notify the game server this computer should be removed
       SendScrapEvent(computer);
-      _computerFactory.Remove(computer);
+      
     }
 
     //--------------------------------------------------------------------------
     private static void SendScrapEvent(ComponentBehavior computer) {
       var xml = new XElement("componentEvent",
         new XElement("name", computer.Data.component_name),
-        new XElement("sell"));
+        new XElement("sell", ""));
 
       IPCManagerScript.SendRequest(xml.ToString());
     }

--- a/Assets/Code/World Objects/Computer/ComputerManager.cs
+++ b/Assets/Code/World Objects/Computer/ComputerManager.cs
@@ -1,4 +1,5 @@
-﻿using Code.Factories;
+﻿using System.Xml.Linq;
+using Code.Factories;
 using UnityEngine;
 
 namespace Code.World_Objects.Computer {
@@ -10,7 +11,17 @@ namespace Code.World_Objects.Computer {
     //--------------------------------------------------------------------------
     public void OnScrapComputer(ComputerBehavior computer) {
       //TODO Notify the game server this computer should be removed
+      SendScrapEvent(computer);
       _computerFactory.Remove(computer);
+    }
+
+    //--------------------------------------------------------------------------
+    private static void SendScrapEvent(ComponentBehavior computer) {
+      var xml = new XElement("componentEvent",
+        new XElement("name", computer.Data.component_name),
+        new XElement("sell"));
+
+      IPCManagerScript.SendRequest(xml.ToString());
     }
   }
 }

--- a/Assets/Prefabs/Game Loader.prefab
+++ b/Assets/Prefabs/Game Loader.prefab
@@ -573,6 +573,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 816d7d7687f22e943a7b02c5ae93bad4, type: 2}
   - {fileID: 11400000, guid: 592fa830322d5f54db48408ebdb3979c, type: 2}
   - {fileID: 11400000, guid: 9b00c609bea7ce94ab448ad9a5df3845, type: 2}
+  _currentlySelectedWorldObject: {fileID: 11400000, guid: 357d0fa733a03e24f82c4b882d71dea0,
+    type: 2}
   computerListVariable: {fileID: 11400000, guid: 8380099111649e944adcc17e9f804d36,
     type: 2}
 --- !u!1 &6549311441437792860

--- a/Assets/Scenes/cyber1.unity
+++ b/Assets/Scenes/cyber1.unity
@@ -1020,7 +1020,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 19
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &580543072
 GameObject:
@@ -1357,7 +1357,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1d7e0a460b3149bb939c58322f81ecde, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _computerFactory: {fileID: 81782333}
 --- !u!4 &839935603
 Transform:
   m_ObjectHideFlags: 0
@@ -1428,7 +1427,7 @@ Transform:
   - {fileID: 2028820168}
   - {fileID: 997302505}
   m_Father: {fileID: 0}
-  m_RootOrder: 18
+  m_RootOrder: 19
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &889158174
 GameObject:
@@ -3021,7 +3020,7 @@ Transform:
   m_Children:
   - {fileID: 491480235}
   m_Father: {fileID: 0}
-  m_RootOrder: 20
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1521650114
 GameObject:
@@ -9779,7 +9778,7 @@ Transform:
   m_Children:
   - {fileID: 1235520678}
   m_Father: {fileID: 0}
-  m_RootOrder: 21
+  m_RootOrder: 22
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2124163309
 GameObject:


### PR DESCRIPTION
Closes #169

Note: Requires new [.exe](https://nps.box.com/s/xn88owrsvj0fhskmf10coqz83vccn6dd)

I think the scrapping of computers now completely works.

To verify:
- Buy a computer and place on a WorkSpace
- From the Component dialog, select that computer and hit the Scrap button.
- Notice:
  - The Computer list changes
  - The GameObject is removed
  - There is no currently selected object
- Purchase a replacement computer for the same workspace.

Note: buying a computer doesn't cost money (#179), but selling it gives you a refund.
