### PR TITLE
Merge Request for Issue/199 - hardware purchase autoselection

### DIFF
--- a/Assets/Code/Factories/ComputerFactory.cs
+++ b/Assets/Code/Factories/ComputerFactory.cs
@@ -30,7 +30,9 @@ namespace Code.Factories {
     [Header("Output Variables")]
     [Tooltip("The variable containing the list of all the Computers currently in the scenario.")]
     [SerializeField] private ComputerListVariable computerListVariable;
-   
+    [Tooltip("Currently selected object in game to show properties for")]
+    public GameObjectVariable selectedObject;
+
     private static readonly string COMPUTERS = "computers";
 
     //-------------------------------------------------------------------------
@@ -43,6 +45,9 @@ namespace Code.Factories {
       ComputerBehavior item = Instantiate(_prefab, parent);
       item.Data = LoadOneComputer(Path.Combine(userAppPath.Value, COMPUTERS, filename), item);
       UpdateGameObject(item);
+
+      // Select our newly created computer
+      selectedObject.Value = item.gameObject;
     }
 
     //-------------------------------------------------------------------------

--- a/Assets/Code/Factories/DeviceFactory.cs
+++ b/Assets/Code/Factories/DeviceFactory.cs
@@ -16,11 +16,15 @@ namespace Code.Factories {
     public StringVariable userAppPath;
     [Tooltip("Variable containing all hardware (computers, servers, routers, etc) information for game")]
     public HardwareCatalogVariable hardwareCatalog;
-    [Tooltip("The variable containing the list of all the Devices currently in the scenario.")]
-    [SerializeField] private DeviceListVariable deviceListVariable;
     [Tooltip("The list of all the currently loaded workspaces")]
     [SerializeField] private WorkSpaceListVariable _workSpaceListVariable;
     
+    [Header("Output Variables")]
+    [Tooltip("The variable containing the list of all the Devices currently in the scenario.")]
+    [SerializeField] private DeviceListVariable deviceListVariable;
+    [Tooltip("Currently selected object in game to show properties for")]
+    public GameObjectVariable selectedObject;
+
     private readonly string DEVICES = "devices";
 
     //-------------------------------------------------------------------------
@@ -33,6 +37,9 @@ namespace Code.Factories {
       DeviceBehavior item = Instantiate(_prefab, parent);
       item.Data = LoadOneDevice(Path.Combine(userAppPath.Value, DEVICES, filename), item);
       UpdateGameObject(item);
+
+      // Select our newly created computer
+      selectedObject.Value = item.gameObject;
     }
 
     //-------------------------------------------------------------------------

--- a/Assets/Prefabs/Game Loader.prefab
+++ b/Assets/Prefabs/Game Loader.prefab
@@ -238,9 +238,10 @@ MonoBehaviour:
   _prefab: {fileID: 3249270980878181615, guid: dcc43fa0d0ad6754a9c3ceaa96ec2b1c, type: 3}
   userAppPath: {fileID: 11400000, guid: f45e161deeec3124abff45892f62adb6, type: 2}
   hardwareCatalog: {fileID: 11400000, guid: 4a97168858329c24db6d4a0d5fa69553, type: 2}
-  deviceListVariable: {fileID: 11400000, guid: 325065c17ecc5144faa9016c6f5e5ede, type: 2}
   _workSpaceListVariable: {fileID: 11400000, guid: d58ae4d2fe18c644789dbe0b0007d8d3,
     type: 2}
+  deviceListVariable: {fileID: 11400000, guid: 325065c17ecc5144faa9016c6f5e5ede, type: 2}
+  selectedObject: {fileID: 11400000, guid: 357d0fa733a03e24f82c4b882d71dea0, type: 2}
 --- !u!1 &6549311439845486866
 GameObject:
   m_ObjectHideFlags: 0
@@ -626,6 +627,7 @@ MonoBehaviour:
     type: 2}
   computerListVariable: {fileID: 11400000, guid: 8380099111649e944adcc17e9f804d36,
     type: 2}
+  selectedObject: {fileID: 11400000, guid: 357d0fa733a03e24f82c4b882d71dea0, type: 2}
 --- !u!1 &6549311441437792860
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Closes #199 

Rather than try to make the ZonePropertyPanel know when to update itself in all sorts of situations, when the user buys a computer or device, it auto selects the new object so the user will have to select the zone again to see its properties, which will be updated.