### PR TITLE
Merge Request for Issue/305 - hiding building button

### DIFF
--- a/Assets/Code/User Interface/Office/BuildingCameraControls.cs
+++ b/Assets/Code/User Interface/Office/BuildingCameraControls.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+using Code.Scriptable_Variables;
+
+namespace Code.User_Interface.Office {
+  public class BuildingCameraControls : MonoBehaviour {
+    [Header("Input Variables")]
+    [Tooltip("List of ViewPoints that represent the different buildings available.")]
+    [SerializeField] private ViewPointListVariable _buildings;
+
+    [Header("UI Elements")]
+    [Tooltip("The root of the controls UI.")]
+    [SerializeField] private GameObject _controlsRoot;
+
+    // ------------------------------------------------------------------------
+    void OnEnable() {
+      _buildings.OnValueChanged += UpdateControlVisibility;
+      UpdateControlVisibility();
+    }
+
+    // ------------------------------------------------------------------------
+    void OnDisable() {
+      _buildings.OnValueChanged -= UpdateControlVisibility;
+    }
+
+    // ------------------------------------------------------------------------
+    private void UpdateControlVisibility() {
+      _controlsRoot.SetActive(_buildings.Value.Count > 1);
+    }
+  }
+}

--- a/Assets/Code/User Interface/Office/BuildingCameraControls.cs.meta
+++ b/Assets/Code/User Interface/Office/BuildingCameraControls.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3ddae894703e7ec4c97c74ac53388fbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/User Interface Elements/Office View/Office View Root.prefab
+++ b/Assets/Prefabs/User Interface Elements/Office View/Office View Root.prefab
@@ -113,6 +113,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 157217906453256319}
+  - component: {fileID: 3743270166332329781}
   m_Layer: 5
   m_Name: Office View Root
   m_TagString: Untagged
@@ -141,6 +142,20 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3743270166332329781
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 157217906453256288}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3ddae894703e7ec4c97c74ac53388fbc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _buildings: {fileID: 11400000, guid: 1acce64078c0fb1478e607551b74ebf3, type: 2}
+  _controlsRoot: {fileID: 1866472305103597011}
 --- !u!1 &157217906814526085
 GameObject:
   m_ObjectHideFlags: 0
@@ -1556,15 +1571,15 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 00f3ce11fde7a5849bacb52e0082670c, type: 3}
---- !u!224 &431592601151257568 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 564040623376407789, guid: 00f3ce11fde7a5849bacb52e0082670c,
-    type: 3}
-  m_PrefabInstance: {fileID: 157217907023226637}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &431592601238933111 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 564040623204313466, guid: 00f3ce11fde7a5849bacb52e0082670c,
+    type: 3}
+  m_PrefabInstance: {fileID: 157217907023226637}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &431592601151257568 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 564040623376407789, guid: 00f3ce11fde7a5849bacb52e0082670c,
     type: 3}
   m_PrefabInstance: {fileID: 157217907023226637}
   m_PrefabAsset: {fileID: 0}
@@ -2037,15 +2052,15 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 00f3ce11fde7a5849bacb52e0082670c, type: 3}
---- !u!1 &2628239052418255848 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 564040623204313466, guid: 00f3ce11fde7a5849bacb52e0082670c,
-    type: 3}
-  m_PrefabInstance: {fileID: 2570076041993822866}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &2628239053420838527 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 564040623376407789, guid: 00f3ce11fde7a5849bacb52e0082670c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2570076041993822866}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2628239052418255848 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 564040623204313466, guid: 00f3ce11fde7a5849bacb52e0082670c,
     type: 3}
   m_PrefabInstance: {fileID: 2570076041993822866}
   m_PrefabAsset: {fileID: 0}
@@ -2371,15 +2386,15 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 00f3ce11fde7a5849bacb52e0082670c, type: 3}
---- !u!1 &3704831545057422661 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 564040623204313466, guid: 00f3ce11fde7a5849bacb52e0082670c,
-    type: 3}
-  m_PrefabInstance: {fileID: 3799326541489669183}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &3704831545933633746 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 564040623376407789, guid: 00f3ce11fde7a5849bacb52e0082670c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3799326541489669183}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3704831545057422661 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 564040623204313466, guid: 00f3ce11fde7a5849bacb52e0082670c,
     type: 3}
   m_PrefabInstance: {fileID: 3799326541489669183}
   m_PrefabAsset: {fileID: 0}
@@ -2538,15 +2553,15 @@ PrefabInstance:
         type: 3}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 00f3ce11fde7a5849bacb52e0082670c, type: 3}
---- !u!1 &5017920378623681689 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 564040623204313466, guid: 00f3ce11fde7a5849bacb52e0082670c,
-    type: 3}
-  m_PrefabInstance: {fileID: 4787577139118820835}
-  m_PrefabAsset: {fileID: 0}
 --- !u!224 &5017920379256623374 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 564040623376407789, guid: 00f3ce11fde7a5849bacb52e0082670c,
+    type: 3}
+  m_PrefabInstance: {fileID: 4787577139118820835}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5017920378623681689 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 564040623204313466, guid: 00f3ce11fde7a5849bacb52e0082670c,
     type: 3}
   m_PrefabInstance: {fileID: 4787577139118820835}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
Closes #305 

To test:
- Run any scenario with only one building (like Training/Stop Worms) and make sure the building camera buttons are hidden
- Run a scenario with multiple buildings (like Training/Identity Theft) and make sure building camera buttons are visible