### PR TITLE
Creates campaign subdirectory during first-time play (resolves #311)

### DIFF
--- a/Assets/Code/Main Menu/CyberCIEGEParser.cs
+++ b/Assets/Code/Main Menu/CyberCIEGEParser.cs
@@ -146,6 +146,9 @@ namespace Code.MainMenu {
     // ------------------------------------------------------------------------
     public static string GetScenarioStatus(string ccInstallPath, string campaign, string scenario) {
       var logDirectory = GetLogDirectory(ccInstallPath, campaign);
+      if (!Directory.Exists(logDirectory)) {
+        Directory.CreateDirectory(logDirectory);
+      }
       var logFiles = Directory.GetFiles(logDirectory, $"{Path.GetFileNameWithoutExtension(scenario)}-*.log");
       var scenarioStatus = SCENARIO_STATUS_NOT_STARTED;
       var phasesReached = new Stack<string>();


### PR DESCRIPTION
To test:
* delete / uninstall directory `CyberCIEGE` 
* download the installer and `SimSecNoUI.exe` as described in README
* install app and copy `SimSecNoUI.exe` into `CyberCIEGE\game\exec`
* launch Unity

The UI of the main menu with the SCENARIO menu fully populated. The game should play without problem after user has chosen a campaign and a scenario.

Closes #311 