### PR TITLE
Issue/348-refactor-computer-positions

### DIFF
--- a/Assets/Code/Factories/WorkspaceFactory.cs
+++ b/Assets/Code/Factories/WorkspaceFactory.cs
@@ -97,9 +97,10 @@ namespace Code.Factories {
             }
 
             WorkSpace ws = new WorkSpace(x, y, dir, usage);
-            _workSpaceListVariable.Add(ws);
-            var workSpace = Instantiate(_prefab, _parent);
+            WorkSpaceScript workSpace = Instantiate(_prefab, _parent);
             workSpace.Data = ws;
+            _workSpaceListVariable.Add(workSpace);
+            
             SetupGameObject(workSpace, wsData, _workSpaceListVariable.Value.Count-1);
           } while (line != "end" && line != null);
         }
@@ -159,10 +160,11 @@ namespace Code.Factories {
     //Instantiate the office furniture for the supplied WorkSpace
     private void PopulateWorkspace(WorkSpaceScript workSpace, WorkSpaceData supplementalData, int index) {
       var mainOffice = _officeList.GetMainOffice();
-      WorkSpaceFurnitureConfiguration workSpaceFurniture = mainOffice.GetWorkSpaceFurniture(workSpace.Data.GetWorkSpaceType());
-      if (workSpaceFurniture) {
-        WorkSpaceFurnitureConfiguration config = Instantiate(workSpaceFurniture, workSpace.transform, false);
+      WorkSpaceFurnitureConfiguration prefab = mainOffice.GetWorkSpaceFurniturePrefab(workSpace.Data.GetWorkSpaceType());
+      if (prefab) {
+        WorkSpaceFurnitureConfiguration config = Instantiate(prefab, workSpace.transform, false);
         config.SetupFurniture(supplementalData.Random1, supplementalData.Random2, index);
+        workSpace.FurnitureConfiguration = config;
       }
     }
   }

--- a/Assets/Code/Scriptable Variables/WorkSpaceListVariable.cs
+++ b/Assets/Code/Scriptable Variables/WorkSpaceListVariable.cs
@@ -2,9 +2,9 @@
 using UnityEngine;
 
 namespace Code.Scriptable_Variables {
-  //A ScriptableVariable that contains a list of WorkSpace data objects
+  //A ScriptableVariable that contains a list of WorkSpaceScript objects
   [CreateAssetMenu(menuName = "Scriptable Objects/Variables/CC/WorkSpace List")]
-  public class WorkSpaceListVariable : ListVariable<WorkSpace> {
+  public class WorkSpaceListVariable : ListVariable<WorkSpaceScript> {
     [ContextMenu("Reset To Default Value")]
     public void ContextMenuReset() {
       Reset();
@@ -19,13 +19,13 @@ namespace Code.Scriptable_Variables {
       float distance = 9999999.9f;
 
       for (int i = 0; i < Value.Count; i++) {
-        float temp = (gridPosition.x - Value[i].x) * (gridPosition.x - Value[i].x)
-                     + (gridPosition.y - Value[i].y) * (gridPosition.y - Value[i].y);
+        float temp = (gridPosition.x - Value[i].Data.x) * (gridPosition.x - Value[i].Data.x)
+                     + (gridPosition.y - Value[i].Data.y) * (gridPosition.y - Value[i].Data.y);
         if (temp < distance) {
           index = i;
           distance = temp;
-          xout = Value[i].x;
-          yout = Value[i].y;
+          xout = Value[i].Data.x;
+          yout = Value[i].Data.y;
         }
       }
 
@@ -38,6 +38,15 @@ namespace Code.Scriptable_Variables {
     
     //-----------------------------------------------------------------------------
     public WorkSpace GetWorkSpace(int pos) {
+      if (pos >= Value.Count || pos < 0) {
+        Debug.Log("Workspace request out of range " + pos);
+        return null;
+      }
+      return Value[pos].Data;
+    }
+
+    //-----------------------------------------------------------------------------
+    public WorkSpaceScript GetWorkSpaceScript(int pos) {
       if (pos >= Value.Count || pos < 0) {
         Debug.Log("Workspace request out of range " + pos);
         return null;

--- a/Assets/Code/World Objects/Office/OfficeBuilding.cs
+++ b/Assets/Code/World Objects/Office/OfficeBuilding.cs
@@ -24,7 +24,7 @@ namespace Code.World_Objects.Office {
 
     //--------------------------------------------------------------------------
     // Get the furniture set prefab for this office building based on the type of WorkSpace.
-    public WorkSpaceFurnitureConfiguration GetWorkSpaceFurniture(WorkSpace.WorkSpaceType workSpaceType) {
+    public WorkSpaceFurnitureConfiguration GetWorkSpaceFurniturePrefab(WorkSpace.WorkSpaceType workSpaceType) {
       switch (workSpaceType) {
         case WorkSpace.WorkSpaceType.Regular:
           return _furniture.RegularOfficeFurniture;

--- a/Assets/Code/World Objects/Workspace/WorkSpaceFurnitureConfiguration.cs
+++ b/Assets/Code/World Objects/Workspace/WorkSpaceFurnitureConfiguration.cs
@@ -4,28 +4,37 @@ namespace Code.World_Objects.Workspace {
   
   //Used to reference a hierarchy of WorkSpace Furniture items
   public class WorkSpaceFurnitureConfiguration : MonoBehaviour {
+    [Header("References")]
     [Tooltip("The root Transform containing all the 'random 1' child furniture objects")]
-    [SerializeField] public Transform Random1Root;
+    [SerializeField] private Transform Random1Root;
     [Tooltip("The root Transform containing all the 'random 2' child furniture objects")]
-    [SerializeField] public Transform Random2Root;
+    [SerializeField] private Transform Random2Root;
+    [Tooltip("The root Transform containing all the empty child Transforms references " +
+             "used to position computers and devices")]
+    [SerializeField] private Transform ComponentRoot;
     [Tooltip("The GameObject to use as the WorkSpace Desk")]
     [SerializeField] public GameObject Desk;
-    
+
     [Header("Misc")]
     [Tooltip("The WorkSpace index values that should *not* provide workspace desks (inclusive)")]
     [SerializeField] public UnityUtilities.RangeInt _invalidIndexRange = new UnityUtilities.RangeInt(-1, -1);
 
-    [Tooltip("The offset from the WorkSpace to use for added Computers, to place them on a desk.")]
-    public WorkSpaceFurnitureOffset ComputerOffset;
-
-    
     //-------------------------------------------------------------------------
     public void SetupFurniture(int random1, int random2, int workSpaceIndex) {
       ActivateChildren(Random1Root, random1, workSpaceIndex);
       ActivateChildren(Random2Root, random2, workSpaceIndex);
       Desk.SetActive(IsApplicableWorkSpaceIndex(workSpaceIndex));
     }
-    
+
+    //-------------------------------------------------------------------------
+    //Get the Transform representing the n-th Component child Transform
+    public Transform GetComponentTransform(int childIndex) {
+      if (childIndex < ComponentRoot.childCount) {
+        return ComponentRoot.GetChild(childIndex);
+      }
+      return null;
+    }
+
     //-------------------------------------------------------------------------
     private void ActivateChildren(Transform parent, int randomChildIndex, int workSpaceIndex) {
       if (parent) {

--- a/Assets/Code/World Objects/Workspace/WorkSpaceScript.cs
+++ b/Assets/Code/World Objects/Workspace/WorkSpaceScript.cs
@@ -5,6 +5,9 @@ namespace Code.World_Objects.Workspace {
     [SerializeField] private WorkSpace _data;
 
     // ------------------------------------------------------------------------
+    public WorkSpaceFurnitureConfiguration FurnitureConfiguration { get; set; }
+
+    // ------------------------------------------------------------------------
     public override WorldObjectType Type() {
       return WorldObjectType.Workspace;
     }

--- a/Assets/Prefabs/Office Workspaces/Office 5 - Server Room.prefab
+++ b/Assets/Prefabs/Office Workspaces/Office 5 - Server Room.prefab
@@ -1,5 +1,35 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &445163445994163102
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5649646623886985438}
+  m_Layer: 0
+  m_Name: Component 6
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5649646623886985438
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 445163445994163102}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.1, y: 0.692, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 139774341598774893}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &534097031620214950
 GameObject:
   m_ObjectHideFlags: 0
@@ -31,6 +61,7 @@ Transform:
   - {fileID: 1055177800785511141}
   - {fileID: 9081001109810599046}
   - {fileID: 7633867786214766195}
+  - {fileID: 139774341598774893}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -48,15 +79,197 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Random1Root: {fileID: 0}
   Random2Root: {fileID: 0}
+  ComponentRoot: {fileID: 139774341598774893}
   Desk: {fileID: 8452661432612294204}
   _invalidIndexRange:
     from: -1
     to: -1
-  ComputerOffset:
-    NorthRelativeOffset: {x: 0.5, y: 0.71, z: 1.5}
-    EastRelativeOffset: {x: 0.5, y: 0.71, z: 1.5}
-    SouthRelativeOffset: {x: 0.5, y: 0.71, z: 2.5}
-    WestRelativeOffset: {x: 0.5, y: 0.71, z: 1.5}
+--- !u!1 &974987325068786466
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 405991998627635032}
+  m_Layer: 0
+  m_Name: Component 4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &405991998627635032
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 974987325068786466}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.053, y: 0.692, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 139774341598774893}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2076411994641541457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8922529834048285243}
+  m_Layer: 0
+  m_Name: Component 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8922529834048285243
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2076411994641541457}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.519, y: 0.796, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 139774341598774893}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3870835228593969645
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6774257323501712323}
+  m_Layer: 0
+  m_Name: Component 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6774257323501712323
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3870835228593969645}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.053, y: 0.192, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 139774341598774893}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4089657024696662120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6599899837474540637}
+  m_Layer: 0
+  m_Name: Component 5
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6599899837474540637
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4089657024696662120}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.1, y: 0.192, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 139774341598774893}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7451076425489046333
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4645173009853603626}
+  m_Layer: 0
+  m_Name: Component 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4645173009853603626
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7451076425489046333}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.519, y: 0.182, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 139774341598774893}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8557882262102319652
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 139774341598774893}
+  m_Layer: 0
+  m_Name: --- Component Positions ---
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &139774341598774893
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8557882262102319652}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8922529834048285243}
+  - {fileID: 4645173009853603626}
+  - {fileID: 6774257323501712323}
+  - {fileID: 405991998627635032}
+  - {fileID: 6599899837474540637}
+  - {fileID: 5649646623886985438}
+  m_Father: {fileID: 8718757912360456849}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &4349192077455879342
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Office Workspaces/Office 5 Workspace Configuration.prefab
+++ b/Assets/Prefabs/Office Workspaces/Office 5 Workspace Configuration.prefab
@@ -1,5 +1,35 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1707832905672722590
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2598051238196760683}
+  m_Layer: 0
+  m_Name: component 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2598051238196760683
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1707832905672722590}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.5, y: 0.71, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4601164839142874655}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3545488913138966219
 GameObject:
   m_ObjectHideFlags: 0
@@ -36,6 +66,37 @@ Transform:
   m_Father: {fileID: 3527024180621134795}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3842553925285425868
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4601164839142874655}
+  m_Layer: 0
+  m_Name: --- Component Positions ----
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4601164839142874655
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3842553925285425868}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2598051238196760683}
+  m_Father: {fileID: 3527024180621134795}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4607007705097901925
 GameObject:
   m_ObjectHideFlags: 0
@@ -68,6 +129,7 @@ Transform:
   - {fileID: 6990389380905723056}
   - {fileID: 1153304374110622942}
   - {fileID: 2334792888261766964}
+  - {fileID: 4601164839142874655}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -85,6 +147,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Random1Root: {fileID: 1153304374110622942}
   Random2Root: {fileID: 2334792888261766964}
+  ComponentRoot: {fileID: 4601164839142874655}
   Desk: {fileID: 4614727172447646569}
   _invalidIndexRange:
     from: -1

--- a/Assets/Prefabs/Office Workspaces/Office 6 - Server Room.prefab
+++ b/Assets/Prefabs/Office Workspaces/Office 6 - Server Room.prefab
@@ -30,6 +30,7 @@ Transform:
   m_Children:
   - {fileID: 2474451484394174945}
   - {fileID: 7085062183428405399}
+  - {fileID: 5862517790038282839}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -47,15 +48,227 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Random1Root: {fileID: 0}
   Random2Root: {fileID: 0}
+  ComponentRoot: {fileID: 5862517790038282839}
   Desk: {fileID: 2962475954706899803}
   _invalidIndexRange:
     from: -1
     to: -1
-  ComputerOffset:
-    NorthRelativeOffset: {x: 0, y: 0.771, z: 2}
-    EastRelativeOffset: {x: 1, y: 0.771, z: 2}
-    SouthRelativeOffset: {x: 0.8, y: 0.771, z: 0.76}
-    WestRelativeOffset: {x: 0, y: 0.771, z: 1}
+--- !u!1 &2700253507469171293
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5405626503510700098}
+  m_Layer: 0
+  m_Name: Component 6
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5405626503510700098
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2700253507469171293}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.119, y: 0.692, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5862517790038282839}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3637084753029413297
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1343560621362596004}
+  m_Layer: 0
+  m_Name: Component 4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1343560621362596004
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3637084753029413297}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.053, y: 0.692, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5862517790038282839}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3879002963896377111
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1445228707594293713}
+  m_Layer: 0
+  m_Name: Component 5
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1445228707594293713
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3879002963896377111}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.119, y: 0.192, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5862517790038282839}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5310066415284822108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6906867835365580661}
+  m_Layer: 0
+  m_Name: Component 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6906867835365580661
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5310066415284822108}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.519, y: 0.796, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5862517790038282839}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8726172713665881171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5862517790038282839}
+  m_Layer: 0
+  m_Name: --- Component Positions ---
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5862517790038282839
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8726172713665881171}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6906867835365580661}
+  - {fileID: 7468646170338815849}
+  - {fileID: 3559587140795780039}
+  - {fileID: 1343560621362596004}
+  - {fileID: 1445228707594293713}
+  - {fileID: 5405626503510700098}
+  m_Father: {fileID: 7371385429926539552}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8929922691217700227
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3559587140795780039}
+  m_Layer: 0
+  m_Name: Component 3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3559587140795780039
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8929922691217700227}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.053, y: 0.192, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5862517790038282839}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9030524899609627450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7468646170338815849}
+  m_Layer: 0
+  m_Name: Component 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7468646170338815849
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9030524899609627450}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.519, y: 0.182, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5862517790038282839}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &5318273389326288590
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Office Workspaces/Office 6 Workspace Configuration.prefab
+++ b/Assets/Prefabs/Office Workspaces/Office 6 Workspace Configuration.prefab
@@ -33,6 +33,67 @@ Transform:
   m_Father: {fileID: 6714807061932616042}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5963308462753322181
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6494683776594873299}
+  m_Layer: 0
+  m_Name: Component 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6494683776594873299
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5963308462753322181}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.5, y: 0.771, z: 1.229}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5837223644702660314}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6403074492904565666
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5837223644702660314}
+  m_Layer: 0
+  m_Name: --- Component Positions
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5837223644702660314
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6403074492904565666}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6494683776594873299}
+  m_Father: {fileID: 6714807061932616042}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7644083873231913904
 GameObject:
   m_ObjectHideFlags: 0
@@ -64,6 +125,7 @@ Transform:
   - {fileID: 5052780765235144601}
   - {fileID: 2520610619455033244}
   - {fileID: 4816005967839502953}
+  - {fileID: 5837223644702660314}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -81,15 +143,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   Random1Root: {fileID: 4816005967839502953}
   Random2Root: {fileID: 0}
+  ComponentRoot: {fileID: 5837223644702660314}
   Desk: {fileID: 5572296313635355939}
   _invalidIndexRange:
     from: 0
     to: 5
-  ComputerOffset:
-    NorthRelativeOffset: {x: 0, y: 0.771, z: 2}
-    EastRelativeOffset: {x: 1, y: 0.771, z: 2}
-    SouthRelativeOffset: {x: 0.8, y: 0.771, z: 0.76}
-    WestRelativeOffset: {x: 0, y: 0.771, z: 1}
 --- !u!1001 &2058216692142621240
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
closes #348 

This is a refactor of how computers are positioned inside of WorkSpaces. Instead of using an awkward position offset, the potential computer positions are defined as Transforms inside of WorkSpace furniture prefabs. 

These changes also have a potential to position multiple computers in one WorkSpace (i.e. the ServerRoom). This positions up to 6 computers in the server rack object. I am not sure about where Devices are meant to go...

To verify:
- Run any scenario. 
- Ensure any scenario-defined computers are already roughly in the correct place on the desks.
-Purchase some computers and assign to WorkSpaces. Ensure they are roughly in the correct place as well.

