### PR TITLE
issue/359-character-avoidance

### DIFF
--- a/Assets/Code/World Objects/User/AI/States/NavigateState.cs
+++ b/Assets/Code/World Objects/User/AI/States/NavigateState.cs
@@ -12,11 +12,25 @@ namespace Code.World_Objects.User.AI.States {
     [SerializeField] private Animator _animator;
     [SerializeField] private Navigator _user;
     [SerializeField] private string _walkingAnimParam = "Walking";
+    
+    //used to manipulate the NavMeshAgent obstacle priority to prevent multiple
+    //agents having the same priority and colliding while navigating.
+    private int _initialPriority = -1;
+    private static int _priorityInc = 0;
 
     //--------------------------------------------------------------------------
     public override void OnStateEnter() {
       if (!_agent.enabled) {
         _agent.enabled = true;
+      }
+
+      if (_initialPriority < 0) {
+        _initialPriority = _agent.avoidancePriority;
+        _priorityInc++;
+        if (_priorityInc > 99) {
+          _priorityInc = 0;
+        }
+        _agent.avoidancePriority = _initialPriority + _priorityInc;
       }
 
       MaybeUpdateAgentDestination();

--- a/Assets/Prefabs/Factory Prefabs/Characters/Staff/IT/Staff AI Logic.prefab
+++ b/Assets/Prefabs/Factory Prefabs/Characters/Staff/IT/Staff AI Logic.prefab
@@ -89,6 +89,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _user: {fileID: 0}
   objectOfInterestTag: Object of Interest
+  _objectsOfInterest: []
 --- !u!1 &1697343023365457893
 GameObject:
   m_ObjectHideFlags: 0
@@ -225,6 +226,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3ac53caf3e674ba69fbcb7692aa7a882, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _distanceTolerance: 1.25
   _agent: {fileID: 0}
   _animator: {fileID: 0}
   _user: {fileID: 0}
@@ -320,6 +322,7 @@ MonoBehaviour:
   _workAnimationParam: 
   _angryAnimationParam: 
   _user: {fileID: 0}
+  _agent: {fileID: 0}
   _calcAnimationDelaySeconds: 5
   _startedWorkingEvent: {fileID: 11400000, guid: 153570822755c0a47872c48cf8b1701a,
     type: 2}


### PR DESCRIPTION
Closes #359 
This attempts to prevent characters from blocking each other by ensuring every NavMeshAgent in the scene has a different obstacle avoidance priority value when navigating.

This is kind of hard to verify.
- Run a scenario and get the Users and Staff wandering around
- In the Unity Scene, try to drag the characters in front of each other to initiate a collision.
- One of the characters should get pushed out of the way by the other

Note: You can see the character's NavMeshAgent's priority in the Inspector after they start walking around.
![image](https://user-images.githubusercontent.com/7308321/110015107-6093a100-7cd8-11eb-9bce-73fe674bacb0.png)
